### PR TITLE
Serv 2026/emit route count metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -103,3 +103,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/vmihailenco/msgpack.v2 v2.9.1 // indirect
 )
+
+go 1.13

--- a/main.go
+++ b/main.go
@@ -361,7 +361,7 @@ func initMetrics(cfg *config.Config) {
 			route.RouteRegistry, err = metrics.NewRegistry(cfg.Metrics)
 		}
 		if err == nil {
-			route.RouteCounter = route.RouteRegistry.GetCounter("routes")
+			route.RouteCounter = route.RouteRegistry.GetCounter("fabio.routes")
 			return
 		}
 		if time.Now().After(deadline) {

--- a/main.go
+++ b/main.go
@@ -361,7 +361,7 @@ func initMetrics(cfg *config.Config) {
 			route.RouteRegistry, err = metrics.NewRegistry(cfg.Metrics)
 		}
 		if err == nil {
-			route.RouteCounter = route.RouteRegistry.GetCounter("fabio.routes")
+			route.RouteGauge = route.RouteRegistry.GetGauge("fabio.routes")
 			return
 		}
 		if time.Now().After(deadline) {

--- a/main.go
+++ b/main.go
@@ -358,6 +358,10 @@ func initMetrics(cfg *config.Config) {
 			route.ServiceRegistry, err = metrics.NewRegistry(cfg.Metrics)
 		}
 		if err == nil {
+			route.RouteRegistry, err = metrics.NewRegistry(cfg.Metrics)
+		}
+		if err == nil {
+			route.RouteCounter = route.RouteRegistry.GetCounter("routes")
 			return
 		}
 		if time.Now().After(deadline) {

--- a/main.go
+++ b/main.go
@@ -358,10 +358,6 @@ func initMetrics(cfg *config.Config) {
 			route.ServiceRegistry, err = metrics.NewRegistry(cfg.Metrics)
 		}
 		if err == nil {
-			route.RouteRegistry, err = metrics.NewRegistry(cfg.Metrics)
-		}
-		if err == nil {
-			route.RouteGauge = route.RouteRegistry.GetGauge("fabio.routes")
 			return
 		}
 		if time.Now().After(deadline) {

--- a/metrics/circonus.go
+++ b/metrics/circonus.go
@@ -90,6 +90,12 @@ func (m *cgmRegistry) GetCounter(name string) Counter {
 	return &cgmCounter{m.metrics, metricName}
 }
 
+// GetGauge returns a gauge for the given metric name.
+func (m *cgmRegistry) GetGauge(name string) Gauge {
+	metricName := fmt.Sprintf("%s`$s", m.prefix, name)
+	return &cgmGauge{m.metrics, metricName}
+}
+
 // GetTimer returns a timer for the given metric name.
 func (m *cgmRegistry) GetTimer(name string) Timer {
 	metricName := fmt.Sprintf("%s`%s", m.prefix, name)
@@ -99,6 +105,16 @@ func (m *cgmRegistry) GetTimer(name string) Timer {
 type cgmCounter struct {
 	metrics *cgm.CirconusMetrics
 	name    string
+}
+
+type cgmGauge struct {
+	metrics *cgm.CirconusMetrics
+	name    string
+}
+
+// Gauge updates the gauge to n.
+func (c *cgmGauge) Update(n int64) {
+	c.metrics.Gauge(c.name, uint64(n))
 }
 
 // Inc increases the counter by n.

--- a/metrics/gometrics.go
+++ b/metrics/gometrics.go
@@ -80,6 +80,10 @@ func (p *gmRegistry) GetCounter(name string) Counter {
 	return gm.GetOrRegisterCounter(name, p.r)
 }
 
+func (p *gmRegistry) GetGauge(name string) Gauge {
+	return gm.GetOrRegisterGauge(name, p.r)
+}
+
 func (p *gmRegistry) GetTimer(name string) Timer {
 	return gm.GetOrRegisterTimer(name, p.r)
 }

--- a/metrics/noop.go
+++ b/metrics/noop.go
@@ -13,6 +13,8 @@ func (p NoopRegistry) UnregisterAll() {}
 
 func (p NoopRegistry) GetCounter(name string) Counter { return noopCounter }
 
+func (p NoopRegistry) GetGauge(name string) Gauge { return noopGauge }
+
 func (p NoopRegistry) GetTimer(name string) Timer { return noopTimer }
 
 var noopCounter = NoopCounter{}
@@ -21,6 +23,13 @@ var noopCounter = NoopCounter{}
 type NoopCounter struct{}
 
 func (c NoopCounter) Inc(n int64) {}
+
+var noopGauge = NoopGauge{}
+
+// NoopGauge is a stub implementation of the Gauge interface.
+type NoopGauge struct{}
+
+func (g NoopGauge) Update(n int64) {}
 
 var noopTimer = NoopTimer{}
 

--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -25,6 +25,11 @@ type Registry interface {
 	// otherwise the existing metric should be returned.
 	GetCounter(name string) Counter
 
+	// GetGauge returns a gauge metric for the given name.
+	// If the metric does not exist yet it should be created
+	// otherwise the existing metric should be returned.
+	GetGauge(name string) Gauge
+
 	// GetTimer returns a timer metric for the given name.
 	// If the metric does not exist yet it should be created
 	// otherwise the existing metric should be returned.
@@ -35,6 +40,11 @@ type Registry interface {
 type Counter interface {
 	// Inc increases the counter value by 'n'.
 	Inc(n int64)
+}
+
+// Gauge defines a metric for gauging events.
+type Gauge interface {
+	Update(n int64)
 }
 
 // Timer defines a metric for counting and timing durations for events.

--- a/route/table.go
+++ b/route/table.go
@@ -26,11 +26,6 @@ var table atomic.Value
 // ServiceRegistry stores the metrics for the services.
 var ServiceRegistry metrics.Registry = metrics.NoopRegistry{}
 
-// RouteRegistry stores route count metrics.
-var RouteRegistry metrics.Registry = metrics.NoopRegistry{}
-
-// RouteGauge gauges the current route count for metric emission.
-var RouteGauge metrics.Gauge
 var currentRouteCount int
 
 // init initializes the routing table.
@@ -49,7 +44,7 @@ func clearRouteCountMetric() {
 }
 
 func updateRouteCountGauge() {
-	RouteGauge.Update(int64(currentRouteCount))
+	metrics.DefaultRegistry.GetGauge("fabio.routes").Update(int64(currentRouteCount))
 }
 
 // GetTable returns the active routing table. The function

--- a/route/table.go
+++ b/route/table.go
@@ -29,8 +29,8 @@ var ServiceRegistry metrics.Registry = metrics.NoopRegistry{}
 // RouteRegistry stores route count metrics.
 var RouteRegistry metrics.Registry = metrics.NoopRegistry{}
 
-// RouteCounter gauges the current route count for metric emission.
-var RouteCounter metrics.Counter
+// RouteGauge gauges the current route count for metric emission.
+var RouteGauge metrics.Gauge
 var currentRouteCount int
 
 // init initializes the routing table.
@@ -39,13 +39,13 @@ func init() {
 }
 
 func incrementRouteCountMetric() {
-	currentRouteCount++
-	RouteCounter.Inc(1)
+	currentRouteCount++ // increment route count
+	RouteGauge.Update(int64(currentRouteCount))
 }
 
 func clearRouteCountMetric() {
-	RouteCounter.Inc(-int64(currentRouteCount))
 	currentRouteCount = 0 // reset route count
+	RouteGauge.Update(int64(currentRouteCount))
 }
 
 // GetTable returns the active routing table. The function

--- a/route/table.go
+++ b/route/table.go
@@ -40,11 +40,15 @@ func init() {
 
 func incrementRouteCountMetric() {
 	currentRouteCount++ // increment route count
-	RouteGauge.Update(int64(currentRouteCount))
+	updateRouteCountGauge()
 }
 
 func clearRouteCountMetric() {
 	currentRouteCount = 0 // reset route count
+	updateRouteCountGauge()
+}
+
+func updateRouteCountGauge() {
 	RouteGauge.Update(int64(currentRouteCount))
 }
 


### PR DESCRIPTION
This PR concerns adding route count metrics to PubNub's Fabio fork. It implements a Gauge, updates the gauge when the `addRoute` method is called, and clears the Gauge when a `NewTable` is created.  